### PR TITLE
VSF (or actually Magento) craps out if country code is not in capitals?!

### DIFF
--- a/frontend/payment-klarna/components/Checkout.vue
+++ b/frontend/payment-klarna/components/Checkout.vue
@@ -108,7 +108,7 @@ export default {
             Object.assign(
             {},
             this.$store.state.checkout.shippingDetails,
-            { country: orderData.shippingAddress.country }
+            { country: orderData.shippingAddress.country.toUpperCase() }
           )
         )
         this.$store.dispatch('cart/syncTotals', { forceServerSync: true })


### PR DESCRIPTION
Fix for a bug in DS-15, where Magento craps out if the country code is not catitalized.
The issue was described in DS-15 and results in error entries in VSF api-error.log of the type:
`Carrier with such method not found: flatrate, flatrate`